### PR TITLE
:heavy_plus_sign: Kotest 의존성 추가

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,8 @@ repositories {
     mavenCentral()
 }
 
+val kotestVersion = "5.8.1"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("org.springframework.boot:spring-boot-starter-security")
@@ -42,6 +44,11 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
     testImplementation("org.springframework.security:spring-security-test")
+
+    // Kotest
+    testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
+    testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:1.3.0")
 
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }


### PR DESCRIPTION
## 요약

> 간단 요약

Kotest 추가했습니다.

Kotest 최신 버전은 5.9.1이지만 kotest extensions가 5.8까지만 지원해서 5.8.1로 추가했습니다

Test arrange / Mocking을 위한 라이브러리는 아직 사용 용도가 불투명하고 
기본적인 테스트 대역을 사용할 수 있으니 추가하지 않았습니다

## 작업 사항

Kotest 추가

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

테스트 코드 작성하실 때 Test arrange용 Fixture 라이브러리나 Mocking 라이브러리를 적극 사용하셨으면 리뷰에 내용 남겨주세요! 추가해두겠습니다

---

### 해결한 이슈

closes: #17
