### PR TITLE
:sparkles: 검색어+ 필터링 기능 구현, 테스트 코드 작성

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/controller/WineController.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/controller/WineController.kt
@@ -21,6 +21,13 @@ class WineController(
     @GetMapping()
     fun getWineList(
         @RequestParam(value = "query", defaultValue = "") query: String,
+        @RequestParam(value = "price") price: Int?,
+        @RequestParam(value = "acidity") acidity: List<Int>?,
+        @RequestParam(value = "body") body: List<Int>?,
+        @RequestParam(value = "sweetness") sweetness: List<Int>?,
+        @RequestParam(value = "tannin") tannin: List<Int>?,
+        @RequestParam(value = "type") type: String?,
+
         @RequestParam(value = "page", defaultValue = "0") page: Int,
         @RequestParam(value = "size", defaultValue = "10") size: Int,
         @RequestParam(value = "sort_by", defaultValue = "id") sortBy: String,
@@ -28,7 +35,12 @@ class WineController(
     ): ResponseEntity<List<WineResponse>> {
         return ResponseEntity.status(HttpStatus.OK).body(
             wineService.getWineList(
-                query = query, page = page, size = size, sortBy = sortBy, direction = direction
+                query = query, price = price,
+                acidity = acidity,
+                body = body,
+                sweetness = sweetness,
+                tannin = tannin,
+                type = type, page = page, size = size, sortBy = sortBy, direction = direction,
             )
         )
     }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/entity/Wine.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/entity/Wine.kt
@@ -31,7 +31,7 @@ class Wine(
 
     @Enumerated(EnumType.STRING)
     @Column(name = "type")
-    val wineType: WineType = WineType.UNDEFINED,
+    val wineType: WineType,
 
     @Column(name = "aroma")
     val aroma: String,

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineQueryDslRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineQueryDslRepository.kt
@@ -5,5 +5,14 @@ import org.springframework.data.domain.Pageable
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
 
 interface WineQueryDslRepository {
-    fun searchWines(query: String, pageable: Pageable): Page<Wine>
+    fun searchWines(
+        query: String,
+        price: Int?,
+        acidity: List<Int>?,
+        body: List<Int>?,
+        sweetness: List<Int>?,
+        tannin: List<Int>?,
+        type: String?,
+        pageable: Pageable,
+    ): Page<Wine>
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineQueryDslRepositoryImpl.kt
@@ -18,7 +18,16 @@ import sparta.nbcamp.wachu.infra.querydsl.QueryDslSupport
 class WineQueryDslRepositoryImpl : WineQueryDslRepository, QueryDslSupport() {
 
     private val wine = QWine.wine
-    override fun searchWines(query: String, pageable: Pageable): Page<Wine> {
+    override fun searchWines(
+        query: String,
+        price: Int?,
+        acidity: List<Int>?,
+        body: List<Int>?,
+        sweetness: List<Int>?,
+        tannin: List<Int>?,
+        type: String?,
+        pageable: Pageable,
+    ): Page<Wine> {
         val whereClause = BooleanBuilder()
 
         whereClause.and(
@@ -26,6 +35,17 @@ class WineQueryDslRepositoryImpl : WineQueryDslRepository, QueryDslSupport() {
                 .or(wine.country.containsIgnoreCase(query))
                 .or(wine.region.containsIgnoreCase(query))
         )
+        if (price != null) whereClause.and(wine.price.loe(price))// 입력받은 가격보다 낮게 조회 예) 54000원 입력시 54000원 이하의 와인 조회
+
+        if (acidity != null) whereClause.and(wine.acidity.between(acidity[0], acidity[1]))
+
+        if (body != null) whereClause.and(wine.body.between(body[0], body[1]))
+
+        if (sweetness != null) whereClause.and(wine.sweetness.between(sweetness[0], sweetness[1]))
+
+        if (tannin != null) whereClause.and(wine.tannin.between(tannin[0], tannin[1]))
+
+        if (!type.isNullOrBlank()) whereClause.and(wine.style.eq(type))
 
         val totalCount = queryFactory.select(wine.count())
             .from(wine)

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineQueryDslRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineQueryDslRepositoryImpl.kt
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import sparta.nbcamp.wachu.domain.wine.entity.QWine
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
 import sparta.nbcamp.wachu.infra.querydsl.QueryDslSupport
 
 @Repository
@@ -45,7 +46,12 @@ class WineQueryDslRepositoryImpl : WineQueryDslRepository, QueryDslSupport() {
 
         if (tannin != null) whereClause.and(wine.tannin.between(tannin[0], tannin[1]))
 
-        if (!type.isNullOrBlank()) whereClause.and(wine.style.eq(type))
+        if (!type.isNullOrBlank()) {
+            val wineTypeEnum = WineType.values().find { it.name.equals(type, ignoreCase = true) }
+            if (wineTypeEnum != null) {
+                whereClause.and(wine.wineType.eq(wineTypeEnum))
+            }
+        }
 
         val totalCount = queryFactory.select(wine.count())
             .from(wine)

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepository.kt
@@ -11,5 +11,14 @@ interface WineRepository {
 
     fun findByIdOrNull(id: Long): Wine?
 
-    fun searchWines(query: String, pageable: Pageable): Page<Wine>
+    fun searchWines(
+        query: String,
+        price: Int?,
+        acidity: List<Int>?,
+        body: List<Int>?,
+        sweetness: List<Int>?,
+        tannin: List<Int>?,
+        type: String?,
+        pageable: Pageable,
+    ): Page<Wine>
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepositoryImpl.kt
@@ -24,7 +24,25 @@ class WineRepositoryImpl(
         return wineJpaRepository.findByIdOrNull(id)
     }
 
-    override fun searchWines(query: String, pageable: Pageable): Page<Wine> {
-        return wineQueryDslRepository.searchWines(query = query, pageable = pageable)
+    override fun searchWines(
+        query: String,
+        price: Int?,
+        acidity: List<Int>?,
+        body: List<Int>?,
+        sweetness: List<Int>?,
+        tannin: List<Int>?,
+        type: String?,
+        pageable: Pageable
+    ): Page<Wine> {
+        return wineQueryDslRepository.searchWines(
+            query = query,
+            price = price,
+            acidity = acidity,
+            body = body,
+            sweetness = sweetness,
+            tannin = tannin,
+            type = type,
+            pageable = pageable
+        )
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineService.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineService.kt
@@ -4,7 +4,20 @@ import sparta.nbcamp.wachu.domain.wine.dto.RecommendWineRequest
 import sparta.nbcamp.wachu.domain.wine.dto.WineResponse
 
 interface WineService {
-    fun getWineList(query: String, page: Int, size: Int, sortBy: String, direction: String): List<WineResponse>
+    fun getWineList(
+        query: String,
+        price: Int?,
+        acidity: List<Int>?,
+        body: List<Int>?,
+        sweetness: List<Int>?,
+        tannin: List<Int>?,
+        type: String?,
+        page: Int,
+        size: Int,
+        sortBy: String,
+        direction: String
+    ): List<WineResponse>
+
     fun getWineById(wineId: Long): WineResponse
     fun compareWine(wineIds: List<Long>): List<WineResponse>
     fun getPopularWineList(page: Int, size: Int, sortBy: String, direction: String): List<WineResponse>

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineServiceImpl.kt
@@ -18,13 +18,28 @@ class WineServiceImpl @Autowired constructor(
 ) : WineService {
     override fun getWineList(
         query: String,
+        price: Int?,
+        acidity: List<Int>?,
+        body: List<Int>?,
+        sweetness: List<Int>?,
+        tannin: List<Int>?,
+        type: String?,
         page: Int,
         size: Int,
         sortBy: String,
         direction: String
     ): List<WineResponse> {
         val pageable: Pageable = PageRequest.of(page, size, getDirection(direction), sortBy)
-        val wines: Page<Wine> = wineRepository.searchWines(pageable = pageable, query = query)
+        val wines: Page<Wine> = wineRepository.searchWines(
+            query = query,
+            price = price,
+            acidity = acidity,
+            body = body,
+            sweetness = sweetness,
+            tannin = tannin,
+            type = type,
+            pageable = pageable
+        )
         return wines.map { WineResponse.from(it) }.toList()
     }
 

--- a/src/test/kotlin/sparta/nbcamp/wachu/domain/wine/WineDBTest.kt
+++ b/src/test/kotlin/sparta/nbcamp/wachu/domain/wine/WineDBTest.kt
@@ -81,7 +81,6 @@ class WineDBTest {
         )
         wine.size shouldBe 7
 
-        //전체 리스트의 수는 5지만 page 의 size 를 2로 설정했으니 wine2의 size 는 2가 되어야함
         val wine2 = wineService.getWineList(
             direction = "asc",
             page = 0,
@@ -95,6 +94,7 @@ class WineDBTest {
             sweetness = null,
             type = null,
         )
+
         wine2.size shouldBe 2
     }
 
@@ -117,9 +117,11 @@ class WineDBTest {
             type = null,
         )
 
-        wine.size shouldBe 1
-        wine[0].name shouldBe "편의점에서 산 와인"
-        wine[0].id shouldBe 3
+        val `직접 필터링 한 값` =
+            DEFAULT_WINE_LIST.filter { it.name.contains("편의점") }
+                .sortedByDescending { it.price }
+
+        wine.size shouldBe `직접 필터링 한 값`.size
     }
 
     @Test
@@ -140,7 +142,13 @@ class WineDBTest {
             sweetness = null,
             type = "RED",
         )
-        wines.size shouldBe 2
+
+        val `직접 필터링 한 값` =
+            DEFAULT_WINE_LIST.filter { it.wineType == WineType.RED }
+                .sortedByDescending { it.price }
+
+
+        wines.size shouldBe `직접 필터링 한 값`.size
     }
 
     @Test
@@ -182,8 +190,12 @@ class WineDBTest {
             sweetness = listOf(300, 777),
             type = null,
         )
-        wines[0].price shouldBe 77700
-        wines[0].name shouldBe "777"
+
+        val `직접 필터링 한 값` =
+            DEFAULT_WINE_LIST.filter { it.body in 0..999 && it.sweetness in 300..777 }
+                .sortedByDescending { it.price }
+        wines[0].price shouldBe `직접 필터링 한 값`[0].price
+        wines[0].name shouldBe `직접 필터링 한 값`[0].name
     }
 
     @Test
@@ -204,7 +216,11 @@ class WineDBTest {
             sweetness = listOf(300, 777),
             type = "UNDEFINED",
         )
-        wines.size shouldBe 0
+        val `직접 필터링 한 값` =
+            DEFAULT_WINE_LIST.filter { it.wineType == WineType.UNDEFINED && it.body in 700..999 && it.sweetness in 300..777 }
+                .sortedByDescending { it.price }
+
+        wines.size shouldBe `직접 필터링 한 값`.count()
     }
 
     @Test
@@ -225,8 +241,13 @@ class WineDBTest {
             sweetness = listOf(1, 1000),
             type = null,
         )
-        wines[0].price shouldBe 77700
-        wines[0].name shouldBe "777"
+
+        val `직접 필터링 한 값` =
+            DEFAULT_WINE_LIST.filter { it.body in 1..1000 && it.sweetness in 1..1000 }.sortedByDescending { it.price }
+
+
+        wines[0].price shouldBe `직접 필터링 한 값`[0].price
+        wines[0].name shouldBe `직접 필터링 한 값`[0].name
     }
 
     @Test
@@ -247,8 +268,12 @@ class WineDBTest {
             sweetness = listOf(1, 1000),
             type = null,
         )
+
+        val `직접 필터링 한 값` =
+            DEFAULT_WINE_LIST.filter { it.name.contains("와인") && it.acidity in 1..130 && it.sweetness in 1..1000 }
+                .sortedByDescending { it.price }.count()
         println("Filtered Wines: ${wines.map { it.name }}")
-        wines.size shouldBe 3
+        wines.size shouldBe `직접 필터링 한 값`
     }
 
     @Test
@@ -269,6 +294,11 @@ class WineDBTest {
             sweetness = listOf(1, 1000),
             type = null,
         )
+
+        val `직접 필터링 한 값` =
+            DEFAULT_WINE_LIST.filter { it.name.contains("와인") && it.acidity in 1..130 && it.sweetness in 1..1000 && it.price in 0..10000 }
+                .sortedByDescending { it.price }
+
         wines.size shouldBe 2
     }
 

--- a/src/test/kotlin/sparta/nbcamp/wachu/domain/wine/WineDBTest.kt
+++ b/src/test/kotlin/sparta/nbcamp/wachu/domain/wine/WineDBTest.kt
@@ -79,7 +79,7 @@ class WineDBTest {
             sweetness = null,
             type = null,
         )
-        wine.size shouldBe 5
+        wine.size shouldBe 7
 
         //전체 리스트의 수는 5지만 page 의 size 를 2로 설정했으니 wine2의 size 는 2가 되어야함
         val wine2 = wineService.getWineList(
@@ -253,6 +253,23 @@ class WineDBTest {
 
     @Test
     fun `금액을 입력하면 해당 금액 이하의 와인 리스트가 나오는지 테스트 하는 함수`() {
+
+        wineJpaRepository.saveAllAndFlush(DEFAULT_WINE_LIST)
+
+        val wines = wineService.getWineList(
+            direction = "desc",
+            page = 0,
+            size = 10,
+            sortBy = "price",
+            query = "와인",
+            acidity = listOf(1, 130),
+            body = null,
+            price = 10000,
+            tannin = null,
+            sweetness = listOf(1, 1000),
+            type = null,
+        )
+        wines.size shouldBe 2
     }
 
     companion object {

--- a/src/test/kotlin/sparta/nbcamp/wachu/domain/wine/WineDBTest.kt
+++ b/src/test/kotlin/sparta/nbcamp/wachu/domain/wine/WineDBTest.kt
@@ -9,6 +9,7 @@ import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.ActiveProfiles
 import sparta.nbcamp.wachu.domain.member.entity.Member
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
 import sparta.nbcamp.wachu.domain.wine.repository.WineJpaRepository
 import sparta.nbcamp.wachu.domain.wine.service.WineService
 
@@ -34,7 +35,13 @@ class WineDBTest {
             page = 0,
             size = 10,
             sortBy = "price",
-            query = ""
+            query = "",
+            acidity = null,
+            body = null,
+            price = null,
+            tannin = null,
+            sweetness = null,
+            type = null,
         )
         wine[0].price shouldBe 2000
 
@@ -43,7 +50,13 @@ class WineDBTest {
             page = 0,
             size = 10,
             sortBy = "price",
-            query = ""
+            query = "",
+            acidity = null,
+            body = null,
+            price = null,
+            tannin = null,
+            sweetness = null,
+            type = null,
         )
         wine2[0].price shouldBe 77700
     }
@@ -58,7 +71,13 @@ class WineDBTest {
             page = 0,
             size = 10,
             sortBy = "price",
-            query = ""
+            query = "",
+            acidity = null,
+            body = null,
+            price = null,
+            tannin = null,
+            sweetness = null,
+            type = null,
         )
         wine.size shouldBe 5
 
@@ -68,7 +87,13 @@ class WineDBTest {
             page = 0,
             size = 2,
             sortBy = "price",
-            query = ""
+            query = "",
+            acidity = null,
+            body = null,
+            price = null,
+            tannin = null,
+            sweetness = null,
+            type = null,
         )
         wine2.size shouldBe 2
     }
@@ -83,12 +108,39 @@ class WineDBTest {
             page = 0,
             size = 10,
             sortBy = "price",
-            query = "편의점"
+            query = "편의점",
+            acidity = null,
+            body = null,
+            price = null,
+            tannin = null,
+            sweetness = null,
+            type = null,
         )
 
         wine.size shouldBe 1
         wine[0].name shouldBe "편의점에서 산 와인"
         wine[0].id shouldBe 3
+    }
+
+    @Test
+    fun `와인 종류를 넣으면 해당 종류에 해당하는 와인이 나오는지 테스트 하는 함수`() {
+
+        wineJpaRepository.saveAllAndFlush(DEFAULT_WINE_LIST)
+
+        val wines = wineService.getWineList(
+            direction = "desc",
+            page = 0,
+            size = 10,
+            sortBy = "price",
+            query = "",
+            acidity = null,
+            body = null,
+            price = null,
+            tannin = null,
+            sweetness = null,
+            type = "RED",
+        )
+        wines.size shouldBe 2
     }
 
     @Test
@@ -112,6 +164,97 @@ class WineDBTest {
         wine.price shouldBe 77700
     }
 
+    @Test
+    fun `당도에 값을 넣으면 해당 값에 해당하는 와인이 나오는지 테스트 하는 함수`() {
+
+        wineJpaRepository.saveAllAndFlush(DEFAULT_WINE_LIST)
+
+        val wines = wineService.getWineList(
+            direction = "desc",
+            page = 0,
+            size = 10,
+            sortBy = "price",
+            query = "",
+            acidity = null,
+            body = listOf(0, 999),
+            price = null,
+            tannin = null,
+            sweetness = listOf(300, 777),
+            type = null,
+        )
+        wines[0].price shouldBe 77700
+        wines[0].name shouldBe "777"
+    }
+
+    @Test
+    fun `한가지의 조건이 틀렸을때 아무것도 안나오는지 테스트 하는 함수`() {
+
+        wineJpaRepository.saveAllAndFlush(DEFAULT_WINE_LIST)
+
+        val wines = wineService.getWineList(
+            direction = "desc",
+            page = 0,
+            size = 10,
+            sortBy = "price",
+            query = "",
+            acidity = null,
+            body = listOf(700, 999),
+            price = null,
+            tannin = null,
+            sweetness = listOf(300, 777),
+            type = "UNDEFINED",
+        )
+        wines.size shouldBe 0
+    }
+
+    @Test
+    fun `당도나 price에  값을 넣고 query를 검색했을때  해당 값에 해당하는 와인이 나오는지 테스트 하는 함수`() {
+
+        wineJpaRepository.saveAllAndFlush(DEFAULT_WINE_LIST)
+
+        val wines = wineService.getWineList(
+            direction = "desc",
+            page = 0,
+            size = 10,
+            sortBy = "price",
+            query = "",
+            acidity = null,
+            body = listOf(1, 1000),
+            price = null,
+            tannin = null,
+            sweetness = listOf(1, 1000),
+            type = null,
+        )
+        wines[0].price shouldBe 77700
+        wines[0].name shouldBe "777"
+    }
+
+    @Test
+    fun `검색어와 조건을 같이 넣었을때 제대로 올바른 리스트를 반환하는지 테스트 하는 함수`() {
+
+        wineJpaRepository.saveAllAndFlush(DEFAULT_WINE_LIST)
+
+        val wines = wineService.getWineList(
+            direction = "desc",
+            page = 0,
+            size = 10,
+            sortBy = "price",
+            query = "와인",
+            acidity = listOf(1, 130),
+            body = null,
+            price = null,
+            tannin = null,
+            sweetness = listOf(1, 1000),
+            type = null,
+        )
+        println("Filtered Wines: ${wines.map { it.name }}")
+        wines.size shouldBe 3
+    }
+
+    @Test
+    fun `금액을 입력하면 해당 금액 이하의 와인 리스트가 나오는지 테스트 하는 함수`() {
+    }
+
     companion object {
 
         // 현재 테스트에서는 DEFAULT_MEMBER_LIST 를 사용하지 않지만 남겨놓음
@@ -125,7 +268,8 @@ class WineDBTest {
                 body = 3,
                 sweetness = 10,
                 tannin = 5,
-                style = "RED",
+                wineType = WineType.WHITE,
+                style = "",
                 aroma = "",
                 kind = "",
                 price = 10000,
@@ -139,7 +283,8 @@ class WineDBTest {
                 body = 300,
                 sweetness = 1000,
                 tannin = 500,
-                style = "WHITE",
+                wineType = WineType.RED,
+                style = "",
                 aroma = "",
                 kind = "",
                 price = 10000,
@@ -153,6 +298,7 @@ class WineDBTest {
                 body = 1300,
                 sweetness = 11000,
                 tannin = 1500,
+                wineType = WineType.ROSE,
                 style = "RED",
                 aroma = "",
                 kind = "",
@@ -167,6 +313,7 @@ class WineDBTest {
                 body = 132,
                 sweetness = 21000,
                 tannin = 1200,
+                wineType = WineType.SPARKLING,
                 style = "RED",
                 aroma = "",
                 kind = "",
@@ -181,12 +328,43 @@ class WineDBTest {
                 body = 777,
                 sweetness = 777,
                 tannin = 777,
-                style = "RED",
+                wineType = WineType.RED,
+                style = "",
                 aroma = "",
                 kind = "",
                 price = 77700,
                 country = "UK",
                 region = "LONDON",
+                embedding = null,
+            ),
+            Wine(
+                name = "부산 사나이 와인",
+                acidity = 10000,
+                body = 0,
+                sweetness = 0,
+                tannin = 10000,
+                wineType = WineType.FORTIFIED,
+                style = "",
+                aroma = "",
+                kind = "",
+                price = 2000,
+                country = "KOREA",
+                region = "BUSAN",
+                embedding = null,
+            ),
+            Wine(
+                name = "농심 와인",
+                acidity = 3,
+                body = 3,
+                sweetness = 2,
+                tannin = 7,
+                wineType = WineType.WHITE,
+                style = "",
+                aroma = "",
+                kind = "",
+                price = 77700,
+                country = "KOREA",
+                region = "SEOUL",
                 embedding = null,
             )
         )


### PR DESCRIPTION


> 간단 요약

타닌,바디,산도,당도,가격에 대한 필터링 검색 기능 구현

## 작업 사항
![pull request용](https://github.com/user-attachments/assets/fcf69cc5-78ec-42f4-b787-3aa8cc2ac785)

타닌,바디,산도,당도를 list형태로 받아서 그 사이 값을 필터링하는 식으로 구현했습니다.
가격은  wine.price.loe(price) 를 이용해서 그 이하의 값들만 필터링 하는 식으로 하였습니다.

작성한 테스트 코드: 
당도에 값을 넣으면 해당 값에 해당하는 와인이 나오는지 테스트
한가지의 조건이 틀렸을때 아무것도 안나오는지 테스트
당도나 price에  값을 넣고 query를 검색했을때  해당 값에 해당하는 와인이 나오는지 테스트
검색어와 조건을 같이 넣었을때 제대로 올바른 리스트를 반환하는지 테스트
금액을 입력하면 해당 금액 이하의 와인 리스트가 나오는지 테스트

> 


## 리뷰 요청 사항(선택)

> 와인 엔티티의       val wineType: WineType = WineType.UNDEFINED 에서  val wineType: WineType로 수정하였습니다. 와인 타입에 대한 필터링을 테스트하는 테스트코드를 작성하면서 해당부분이 필요하여 수정하였습니다.

LIST에 값을 2개  초과해서 넣었을 경우에 발생하는 예외처리는 작성하지 않았습니다.  필요하면 구현하겠습니다.
---

### 해결한 이슈

closes: #37 
