### PR TITLE
:sparkles: 페어링 FetchJoin

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/dto/v1/PairingRequest.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/dto/v1/PairingRequest.kt
@@ -1,6 +1,7 @@
 package sparta.nbcamp.wachu.domain.pairing.dto.v1
 
 import sparta.nbcamp.wachu.domain.pairing.model.v1.Pairing
+import sparta.nbcamp.wachu.domain.wine.entity.Wine
 
 data class PairingRequest(
     val wineId: Long,
@@ -9,9 +10,9 @@ data class PairingRequest(
     val photo: String,
 ) {
     companion object {
-        fun toEntity(memberId: Long, pairingRequest: PairingRequest): Pairing {
+        fun toEntity(wine: Wine, memberId: Long, pairingRequest: PairingRequest): Pairing {
             return Pairing(
-                wineId = pairingRequest.wineId,
+                wine = wine,
                 memberId = memberId,
                 title = pairingRequest.title,
                 description = pairingRequest.description,

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/dto/v1/PairingResponse.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/dto/v1/PairingResponse.kt
@@ -1,11 +1,12 @@
 package sparta.nbcamp.wachu.domain.pairing.dto.v1
 
 import sparta.nbcamp.wachu.domain.pairing.model.v1.Pairing
+import sparta.nbcamp.wachu.domain.wine.dto.WineResponse
 import java.time.LocalDateTime
 
 data class PairingResponse(
     val id: Long,
-    val wineId: Long,
+    val wine: WineResponse,
     val memberId: Long,
     val title: String,
     val description: String,
@@ -16,7 +17,7 @@ data class PairingResponse(
         fun from(pairing: Pairing): PairingResponse {
             return PairingResponse(
                 id = pairing.id!!,
-                wineId = pairing.wine.id,
+                wine = WineResponse.from(pairing.wine),
                 memberId = pairing.memberId,
                 title = pairing.title,
                 description = pairing.description,

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/dto/v1/PairingResponse.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/dto/v1/PairingResponse.kt
@@ -16,7 +16,7 @@ data class PairingResponse(
         fun from(pairing: Pairing): PairingResponse {
             return PairingResponse(
                 id = pairing.id!!,
-                wineId = pairing.wineId,
+                wineId = pairing.wine.id,
                 memberId = pairing.memberId,
                 title = pairing.title,
                 description = pairing.description,

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/model/v1/Pairing.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/model/v1/Pairing.kt
@@ -2,16 +2,22 @@ package sparta.nbcamp.wachu.domain.pairing.model.v1
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import org.hibernate.annotations.CreationTimestamp
+import sparta.nbcamp.wachu.domain.wine.entity.Wine
 import java.time.LocalDateTime
 
 @Entity(name = "pairing")
 class Pairing(
-    @Column
-    val wineId: Long,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "wine_id")
+    val wine: Wine,
 
     @Column
     val memberId: Long,

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/model/v1/Pairing.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/model/v1/Pairing.kt
@@ -8,11 +8,13 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
 import java.time.LocalDateTime
 
-@Entity(name = "pairing")
+@Entity
+@Table(name = "pairing")
 class Pairing(
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/repository/v1/PairingQueryDslRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/repository/v1/PairingQueryDslRepository.kt
@@ -13,17 +13,14 @@ class PairingQueryDslRepository : QueryDslSupport() {
     private val pairing = QPairing.pairing
 
     fun findPage(pageable: Pageable): Page<Pairing> {
-        val total = queryFactory
-            .select(pairing.count())
-            .from(pairing)
-            .fetchOne()
-            ?: 0L
-
-        val query = queryFactory
+        val results = queryFactory
             .selectFrom(pairing)
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
-        val content = query.fetch()
+            .fetch()
+
+        val content = results.toList()
+        val total = results.count().toLong()
 
         val page = PageImpl(content, pageable, total)
         return page

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/repository/v1/PairingQueryDslRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/repository/v1/PairingQueryDslRepository.kt
@@ -15,8 +15,9 @@ class PairingQueryDslRepository : QueryDslSupport() {
     private val wine = QWine.wine
 
     fun findPage(pageable: Pageable): Page<Pairing> {
-        val basicResults = queryFactory
+        val content = queryFactory
             .selectFrom(pairing)
+            .leftJoin(pairing.wine, wine).fetchJoin()
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
@@ -25,14 +26,6 @@ class PairingQueryDslRepository : QueryDslSupport() {
             .select(pairing.count())
             .from(pairing)
             .fetchOne() ?: 0L
-
-        val content = basicResults.mapNotNull { basicPairing ->
-            queryFactory
-                .selectFrom(pairing)
-                .leftJoin(pairing.wine, wine).fetchJoin()
-                .where(pairing.id.eq(basicPairing.id))
-                .fetchOne()
-        }
 
         return PageImpl(content, pageable, total)
     }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/repository/v1/PairingQueryDslRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/repository/v1/PairingQueryDslRepository.kt
@@ -6,23 +6,34 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 import sparta.nbcamp.wachu.domain.pairing.model.v1.Pairing
 import sparta.nbcamp.wachu.domain.pairing.model.v1.QPairing
+import sparta.nbcamp.wachu.domain.wine.entity.QWine
 import sparta.nbcamp.wachu.infra.querydsl.QueryDslSupport
 
 @Repository
 class PairingQueryDslRepository : QueryDslSupport() {
     private val pairing = QPairing.pairing
+    private val wine = QWine.wine
 
     fun findPage(pageable: Pageable): Page<Pairing> {
-        val results = queryFactory
+        val basicResults = queryFactory
             .selectFrom(pairing)
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
             .fetch()
 
-        val content = results.toList()
-        val total = results.count().toLong()
+        val total = queryFactory
+            .select(pairing.count())
+            .from(pairing)
+            .fetchOne() ?: 0L
 
-        val page = PageImpl(content, pageable, total)
-        return page
+        val content = basicResults.mapNotNull { basicPairing ->
+            queryFactory
+                .selectFrom(pairing)
+                .leftJoin(pairing.wine, wine).fetchJoin()
+                .where(pairing.id.eq(basicPairing.id))
+                .fetchOne()
+        }
+
+        return PageImpl(content, pageable, total)
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/service/v1/PairingServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/service/v1/PairingServiceImpl.kt
@@ -8,12 +8,14 @@ import sparta.nbcamp.wachu.domain.member.repository.MemberRepository
 import sparta.nbcamp.wachu.domain.pairing.dto.v1.PairingRequest
 import sparta.nbcamp.wachu.domain.pairing.dto.v1.PairingResponse
 import sparta.nbcamp.wachu.domain.pairing.repository.v1.PairingRepository
+import sparta.nbcamp.wachu.domain.wine.repository.WineRepository
 import sparta.nbcamp.wachu.exception.AccessDeniedException
 import sparta.nbcamp.wachu.exception.ModelNotFoundException
 import sparta.nbcamp.wachu.infra.security.jwt.UserPrincipal
 
 @Service
 class PairingServiceImpl(
+    private val wineRepository: WineRepository,
     private val memberRepository: MemberRepository,
     private val pairingRepository: PairingRepository,
 ) : PairingService {
@@ -32,9 +34,11 @@ class PairingServiceImpl(
 
     @Transactional
     override fun createPairing(userPrincipal: UserPrincipal, pairingRequest: PairingRequest): PairingResponse {
+        val wine = wineRepository.findByIdOrNull(pairingRequest.wineId)
+            ?: throw ModelNotFoundException("Wine", pairingRequest.wineId)
         val member = memberRepository.findById(userPrincipal.memberId)
             ?: throw ModelNotFoundException("Member", userPrincipal.memberId)
-        val pairing = PairingRequest.toEntity(member.id!!, pairingRequest)
+        val pairing = PairingRequest.toEntity(wine, member.id!!, pairingRequest)
         return PairingResponse.from(pairingRepository.save(pairing))
     }
 

--- a/src/test/kotlin/sparta/nbcamp/wachu/domain/pairing/service/PairingServiceTest.kt
+++ b/src/test/kotlin/sparta/nbcamp/wachu/domain/pairing/service/PairingServiceTest.kt
@@ -13,13 +13,34 @@ import sparta.nbcamp.wachu.domain.pairing.dto.v1.PairingRequest
 import sparta.nbcamp.wachu.domain.pairing.model.v1.Pairing
 import sparta.nbcamp.wachu.domain.pairing.repository.PairingTestRepositoryImpl
 import sparta.nbcamp.wachu.domain.pairing.service.v1.PairingServiceImpl
+import sparta.nbcamp.wachu.domain.wine.entity.Wine
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
+import sparta.nbcamp.wachu.domain.wine.repository.WineRepository
 import sparta.nbcamp.wachu.exception.AccessDeniedException
 import sparta.nbcamp.wachu.exception.ModelNotFoundException
 import sparta.nbcamp.wachu.infra.security.jwt.UserPrincipal
 
 class PairingServiceTest {
+
+    val defaultWine = Wine(
+        id = 1L,
+        name = "testWine",
+        sweetness = 0,
+        acidity = 0,
+        body = 0,
+        tannin = 0,
+        wineType = WineType.RED,
+        aroma = "test",
+        price = 0,
+        kind = "test",
+        style = "test",
+        country = "test",
+        region = "test",
+        embedding = "test"
+    )
+
     val defaultPairing = Pairing(
-        wineId = 1L,
+        wine = defaultWine,
         memberId = 1L,
         title = "test",
         description = "test",
@@ -28,7 +49,7 @@ class PairingServiceTest {
 
     val defaultPairingList = List(10) { index ->
         Pairing(
-            wineId = index.toLong(),
+            wine = defaultWine,
             memberId = index.toLong(),
             title = "test$index",
             description = "testDescription$index",
@@ -39,10 +60,11 @@ class PairingServiceTest {
     val defaultPageable = PageRequest.of(0, 10)
     val defaultPairingPage = PageImpl(defaultPairingList, defaultPageable, defaultPairingList.size.toLong())
 
+    val wineRepository: WineRepository = mockk()
     val memberRepository: MemberRepository = mockk()
     val pairingRepository = PairingTestRepositoryImpl(defaultPairing, defaultPairingPage)
 
-    val pairingService = PairingServiceImpl(memberRepository, pairingRepository)
+    val pairingService = PairingServiceImpl(wineRepository, memberRepository, pairingRepository)
 
     @Test
     fun `존재하는 아이디로 getPairing하면 PairingResponseDto를 반환한다`() {
@@ -51,7 +73,7 @@ class PairingServiceTest {
         responseDto.id shouldBe defaultPairing.id
         responseDto.title shouldBe defaultPairing.title
         responseDto.memberId shouldBe defaultPairing.memberId
-        responseDto.wineId shouldBe defaultPairing.wineId
+        responseDto.wineId shouldBe defaultPairing.wine.id
         responseDto.photoUrl shouldBe defaultPairing.photoUrl
         responseDto.createdAt shouldBe defaultPairing.createdAt
         responseDto.description shouldBe defaultPairing.description
@@ -81,7 +103,8 @@ class PairingServiceTest {
             description = "newTest",
             photo = "newTest"
         )
-
+        val testWine = defaultWine
+        every { wineRepository.findByIdOrNull(1L) } returns testWine
         val testUserPrincipal = UserPrincipal(memberId = 1L, memberRole = setOf("MEMBER"))
         every { memberRepository.findById(any()) } returns Member(
             "test", "test", "test", "test"
@@ -91,7 +114,7 @@ class PairingServiceTest {
 
         response.title shouldBe pairingCreateRequest.title
         response.memberId shouldBe testUserPrincipal.memberId
-        response.wineId shouldBe pairingCreateRequest.wineId
+        response.wineId shouldBe testWine.id
         response.photoUrl shouldBe pairingCreateRequest.photo
         response.description shouldBe pairingCreateRequest.description
     }

--- a/src/test/kotlin/sparta/nbcamp/wachu/domain/pairing/service/PairingServiceTest.kt
+++ b/src/test/kotlin/sparta/nbcamp/wachu/domain/pairing/service/PairingServiceTest.kt
@@ -13,6 +13,7 @@ import sparta.nbcamp.wachu.domain.pairing.dto.v1.PairingRequest
 import sparta.nbcamp.wachu.domain.pairing.model.v1.Pairing
 import sparta.nbcamp.wachu.domain.pairing.repository.PairingTestRepositoryImpl
 import sparta.nbcamp.wachu.domain.pairing.service.v1.PairingServiceImpl
+import sparta.nbcamp.wachu.domain.wine.dto.WineResponse
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
 import sparta.nbcamp.wachu.domain.wine.repository.WineRepository
@@ -68,12 +69,14 @@ class PairingServiceTest {
 
     @Test
     fun `존재하는 아이디로 getPairing하면 PairingResponseDto를 반환한다`() {
+
         val responseDto = pairingService.getPairing(1L)
+        val wineResponseDto = WineResponse.from(defaultWine)
 
         responseDto.id shouldBe defaultPairing.id
         responseDto.title shouldBe defaultPairing.title
         responseDto.memberId shouldBe defaultPairing.memberId
-        responseDto.wineId shouldBe defaultPairing.wine.id
+        responseDto.wine shouldBe wineResponseDto
         responseDto.photoUrl shouldBe defaultPairing.photoUrl
         responseDto.createdAt shouldBe defaultPairing.createdAt
         responseDto.description shouldBe defaultPairing.description
@@ -105,6 +108,7 @@ class PairingServiceTest {
         )
         val testWine = defaultWine
         every { wineRepository.findByIdOrNull(1L) } returns testWine
+        val testWineResponse = WineResponse.from(testWine)
         val testUserPrincipal = UserPrincipal(memberId = 1L, memberRole = setOf("MEMBER"))
         every { memberRepository.findById(any()) } returns Member(
             "test", "test", "test", "test"
@@ -114,7 +118,7 @@ class PairingServiceTest {
 
         response.title shouldBe pairingCreateRequest.title
         response.memberId shouldBe testUserPrincipal.memberId
-        response.wineId shouldBe testWine.id
+        response.wine shouldBe testWineResponse
         response.photoUrl shouldBe pairingCreateRequest.photo
         response.description shouldBe pairingCreateRequest.description
     }


### PR DESCRIPTION

## 요약

> 페어링과 와인을 FetchJoin 
Projection, Pagination 중 Pagination 택,
Pagination + Fetch join 2단계 분리

## 작업 사항

>  - [x] JPA 연관관계 설정 (단방향 @ManyToOne 권장)
>  - [x]  QueryDSL Fetch join 설정
>  - [ ]  QueryDSL 적용 전후의 쿼리 / 성능 시간 비교
>  - [x]  테스트 코드 작성

## 리뷰 요청 사항(선택)

> 페치조인이 첨이라 좀 어색하네여
리뷰 주시면 반영해서 수정하고  before/after 성능비교 드가겟슴다

---

### 해결한 이슈

closes: # 아직 안닫음
