### PR TITLE
:sparkles: WineImage 보여주기 기능 추가

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/dto/WineResponse.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/dto/WineResponse.kt
@@ -2,6 +2,7 @@ package sparta.nbcamp.wachu.domain.wine.dto
 
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
+import sparta.nbcamp.wachu.domain.wine.service.WineImageGetter
 import java.io.Serializable
 
 data class WineResponse(
@@ -19,9 +20,10 @@ data class WineResponse(
     val style: String?,
     val country: String?,
     val region: String?,
+    val imageUrl: String
 ) : Serializable {
-
     companion object {
+
         fun from(entity: Wine): WineResponse {
             return WineResponse(
                 id = entity.id,
@@ -37,6 +39,7 @@ data class WineResponse(
                 style = entity.style,
                 country = entity.country,
                 region = entity.region,
+                imageUrl = WineImageGetter.getWineImage(entity.wineType)
             )
         }
     }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/entity/WineType.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/entity/WineType.kt
@@ -1,5 +1,10 @@
 package sparta.nbcamp.wachu.domain.wine.entity
 
-enum class WineType {
-    RED, WHITE, SPARKLING, ROSE, FORTIFIED, UNDEFINED
+enum class WineType(val path: String) {
+    RED("red/"),
+    WHITE("white/"),
+    SPARKLING("sparkling/"),
+    ROSE("rose/"),
+    FORTIFIED("fortified/"),
+    UNDEFINED("undefined/"),
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineImageGetter.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineImageGetter.kt
@@ -1,0 +1,19 @@
+package sparta.nbcamp.wachu.domain.wine.service
+
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
+import sparta.nbcamp.wachu.infra.aws.s3.S3FilePath
+import sparta.nbcamp.wachu.infra.media.MediaS3Service
+
+object WineImageGetter {
+    private lateinit var mediaS3Service: MediaS3Service
+
+    fun getWineImage(wineType: WineType): String {
+        val list = mediaS3Service.getS3Image(S3FilePath.WINE.path + wineType.path)
+        list.removeFirst()//첫번째 원소는 파일경로만 있어서 제외
+        return list.random()
+    }
+
+    fun init(mediaS3Service: MediaS3Service) {
+        this.mediaS3Service = mediaS3Service
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineServiceImpl.kt
@@ -20,7 +20,7 @@ import sparta.nbcamp.wachu.infra.openai.service.WineEmbeddingService
 class WineServiceImpl @Autowired constructor(
     private val wineRepository: WineRepository,
     private val winePromotionRepository: WinePromotionRepository,
-    private val wineEmbeddingService: WineEmbeddingService
+    private val wineEmbeddingService: WineEmbeddingService,
 ) : WineService {
 
     override fun getWineList(

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/AwsConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/AwsConfig.kt
@@ -4,6 +4,9 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.s3.S3Client
 
 @Configuration
 class AwsConfig {
@@ -14,8 +17,12 @@ class AwsConfig {
     private val secretKey: String? = null
 
     @Bean
-    fun awsBasicCredentials(): AwsBasicCredentials {
+    fun awsBasicCredentials(): S3Client {
         //S3 엑세스 config
-        return AwsBasicCredentials.create(accessKey, secretKey)
+        val credentials = AwsBasicCredentials.create(accessKey, secretKey)
+        return S3Client.builder()
+            .region(Region.AP_NORTHEAST_2) // 원하는 지역으로 설정
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build()
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3FilePath.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3FilePath.kt
@@ -3,5 +3,6 @@ package sparta.nbcamp.wachu.infra.aws.s3
 enum class S3FilePath(val path: String) {
     PAIRING("pairing/"),
     PROFILE("profile/"),
-    REVIEW("review/")
+    REVIEW("review/"),
+    WINE("wine/")
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
@@ -4,28 +4,21 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.core.sync.RequestBody
-import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request
 import software.amazon.awssdk.services.s3.model.PutObjectRequest
 import java.io.IOException
 
 @Service
 class S3Service @Autowired constructor(
-    private val credentials: AwsBasicCredentials,
+    private val s3client: S3Client,
 ) {
     @Value("\${aws.s3.bucket}")
     private lateinit var bucket: String
 
     @Throws(IOException::class)
     fun upload(file: MultipartFile, filePath: String): String {
-
-        val s3 = S3Client.builder()
-            .region(Region.AP_NORTHEAST_2) // 원하는 지역으로 설정
-            .credentialsProvider(StaticCredentialsProvider.create(credentials))
-            .build()
 
         val keyName = filePath + file.originalFilename // S3에 저장할 파일 경로 및 이름
 
@@ -36,9 +29,21 @@ class S3Service @Autowired constructor(
             .build()
 
         // S3에 파일 업로드
-        s3.putObject(putObjectRequest, RequestBody.fromInputStream(file.inputStream, file.size))
+        s3client.putObject(putObjectRequest, RequestBody.fromInputStream(file.inputStream, file.size))
 
         // 업로드된 파일의 CDN URL 반환
         return "https://d3i8tzom3e0at0.cloudfront.net/$keyName"
+    }
+
+    fun getImage(filePath: String): List<String> {
+        val imageList = s3client.listObjectsV2(
+            ListObjectsV2Request.builder()
+                .bucket(bucket)
+                .prefix(filePath)
+                .build()
+        )
+        return imageList.contents().map {
+            "https://d3i8tzom3e0at0.cloudfront.net/${it.key()}"
+        }
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
@@ -32,7 +32,7 @@ class S3Service @Autowired constructor(
         s3client.putObject(putObjectRequest, RequestBody.fromInputStream(file.inputStream, file.size))
 
         // 업로드된 파일의 CDN URL 반환
-        return "https://d3i8tzom3e0at0.cloudfront.net/$keyName"
+        return "https://cdn.sober-wachu.com/$keyName"
     }
 
     fun getImage(filePath: String): List<String> {
@@ -43,7 +43,7 @@ class S3Service @Autowired constructor(
                 .build()
         )
         return imageList.contents().map {
-            "https://d3i8tzom3e0at0.cloudfront.net/${it.key()}"
+            "https://cdn.sober-wachu.com/${it.key()}"
         }
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3Service.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3Service.kt
@@ -5,4 +5,5 @@ import org.springframework.web.multipart.MultipartFile
 interface MediaS3Service {
     fun upload(file: MultipartFile, filePath: String): String
     fun upload(fileList: List<MultipartFile>, filePath: String): List<String>
+    fun getS3Image(filePath: String): MutableList<String>
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3ServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3ServiceImpl.kt
@@ -1,8 +1,10 @@
 package sparta.nbcamp.wachu.infra.media
 
+import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
+import sparta.nbcamp.wachu.domain.wine.service.WineImageGetter
 import sparta.nbcamp.wachu.infra.aws.s3.S3Service
 import sparta.nbcamp.wachu.infra.tika.TikaUtil
 
@@ -27,5 +29,15 @@ class MediaS3ServiceImpl(
         //없으면 전체 upload
         logger.info("upload files: $filePath")
         return fileList.map { s3Service.upload(it, filePath) }
+    }
+
+    override fun getS3Image(filePath: String): MutableList<String> {
+        //경로 안에 모든 파일을 불러옴
+        return s3Service.getImage(filePath).toMutableList()
+    }
+
+    @PostConstruct
+    fun init() {
+        WineImageGetter.init(this)
     }
 }


### PR DESCRIPTION
> 간단 요약

## S3 버킷에 있는 와인 이미지를 불러오는 기능
1. Response시 WineImageGetter 를 통해 S3버킷 주소+wineType 을 하여 경로를 전달(wineType과 S3 wine폴더 경로가 매칭되어 있음)
2. mediaService에서 해당 경로를 통해 하위 파일들의 url를 전부 cdn 처리하여 반환
3. 반환된 값에서 .random()을 통해 하위 파일중 랜덤이미지를 뽑음

## 리뷰 요청 사항(선택)

> 연관관계 매핑으로 인해 와인 이미지의 주소를 여러 서비스에서 필요로 하다보니
싱글톤으로 Response에서 이 일을 처리하도록 하였습니다. 더 좋은 방안이 있다면 의견남겨 주시고, 이를 설정한 패키지 구조를 봐주세요. 

---

### 해결한 이슈

closes: #72 
