### PR TITLE
:sparkles: 빌드 분리와 OAuth 수정, 로그아웃 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,4 +290,6 @@ gradle-app.setting
 /.jqwik-database
 application.properties
 application.yml
+application-dev.yml
+application-prod.yml
 /data

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
@@ -1,5 +1,6 @@
 package sparta.nbcamp.wachu.domain.member.controller
 
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -52,6 +53,20 @@ class MemberController(
 
         return ResponseEntity.status(HttpStatus.OK).header(HttpHeaders.SET_COOKIE, cookie.toString())
             .body(token.accessToken)
+    }
+
+    @PostMapping("/auth/logout")
+    fun logout(response: HttpServletResponse): ResponseEntity<Void> {
+        val deleteCookie = ResponseCookie.from("refreshToken", "")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("None")
+            .maxAge(0)
+            .path("/")
+            .build()
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).header(HttpHeaders.SET_COOKIE, deleteCookie.toString())
+            .build()
     }
 
     @PostMapping(

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/security/WebConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/security/WebConfig.kt
@@ -12,7 +12,11 @@ class WebConfig {
     fun corsConfigurer(): WebMvcConfigurer {
         return object : WebMvcConfigurer {
             override fun addCorsMappings(registry: CorsRegistry) {
-                registry.addMapping("/**").allowedOrigins("*")
+                registry.addMapping("/**")
+                    .allowedOrigins("http://localhost:5173", "https://sober-wachu.com")
+                    .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                    .allowedHeaders("*")
+                    .allowCredentials(true)
             }
         }
     }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/security/oauth/controller/OAuth2LoginController.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/security/oauth/controller/OAuth2LoginController.kt
@@ -3,6 +3,7 @@ package sparta.nbcamp.wachu.infra.security.oauth.controller
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.servlet.http.HttpSession
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseCookie
@@ -16,6 +17,7 @@ import sparta.nbcamp.wachu.infra.security.oauth.service.OAuth2LoginService
 @RestController
 class OAuth2LoginController(
     private val OAuth2LoginService: OAuth2LoginService,
+    @Value("\${frontend.url}") private val frontendUrl: String
 ) {
     private val logger = LoggerFactory.getLogger(OAuth2LoginController::class.java)
 
@@ -35,12 +37,12 @@ class OAuth2LoginController(
 
     @GetMapping("/oauth2/callback/kakao")
     fun kakaoCallback(
-        @RequestParam code: String
-    ): ResponseEntity<String> {
-
+        @RequestParam code: String,
+        response: HttpServletResponse
+    ): ResponseEntity<Void> {
         val token: TokenResponse = OAuth2LoginService.kakaoRetrieveUserInfo(code)
 
-        val cookie = ResponseCookie.from("refreshToken", token.refreshToken)
+        val refreshTokenCookie = ResponseCookie.from("refreshToken", token.refreshToken)
             .httpOnly(true)
             .secure(true)
             .sameSite("None")
@@ -48,18 +50,21 @@ class OAuth2LoginController(
             .path("/")
             .build()
 
-        return ResponseEntity.status(HttpStatus.OK).header(HttpHeaders.SET_COOKIE, cookie.toString())
-            .body(token.accessToken)
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+
+        val redirectUrl = "$frontendUrl/login/oauth-redirect?accessToken=${token.accessToken}"
+        return ResponseEntity.status(HttpStatus.FOUND).header(HttpHeaders.LOCATION, redirectUrl).build()
     }
 
     @GetMapping("/oauth2/callback/naver")
     fun naverCallback(
         @RequestParam code: String,
         @RequestParam state: String,
-    ): ResponseEntity<String> {
+        response: HttpServletResponse
+    ): ResponseEntity<Void> {
         val token: TokenResponse = OAuth2LoginService.naverRetrieveUserInfo(code, state)
 
-        val cookie = ResponseCookie.from("refreshToken", token.refreshToken)
+        val refreshTokenCookie = ResponseCookie.from("refreshToken", token.refreshToken)
             .httpOnly(true)
             .secure(true)
             .sameSite("None")
@@ -67,7 +72,9 @@ class OAuth2LoginController(
             .path("/")
             .build()
 
-        return ResponseEntity.status(HttpStatus.OK).header(HttpHeaders.SET_COOKIE, cookie.toString())
-            .body(token.accessToken)
+        response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString())
+
+        val redirectUrl = "$frontendUrl/login/oauth-redirect?accessToken=${token.accessToken}"
+        return ResponseEntity.status(HttpStatus.FOUND).header(HttpHeaders.LOCATION, redirectUrl).build()
     }
 }


### PR DESCRIPTION
## 요약

> 간단 요약

빌드 분리와 OAuth 수정, 로그아웃 추가

## 작업 사항

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

빌드 분리 (dev, prod)
OAuth 반환을 redirect location 으로 수정
refreshToken을 제거해주는 로그아웃 기능 추가

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

이슈 하나에서 다 처리하면 안되는데 하다보니 작은 기능들이라 한번에 진행했습니다

프론트에서 OAuth 진행할 때 response 가 나오는 방식때문에 빌드 분리 / OAuth response를 수정했고 

로그아웃 기능은 겸사겸사 http-only 쿠키인 refreshToken 을 제거해주려면 필요해서 WebConfig 과 API를 추가했습니다

---

### 해결한 이슈

closes: #94
