### PR TITLE
:sparkles: 이메일 비동기 스레드

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
@@ -21,7 +21,6 @@ import sparta.nbcamp.wachu.domain.member.emailcode.dto.SendCodeRequest
 import sparta.nbcamp.wachu.domain.member.emailcode.service.CodeService
 import sparta.nbcamp.wachu.domain.member.service.MemberService
 import sparta.nbcamp.wachu.infra.security.jwt.UserPrincipal
-import java.util.concurrent.CompletableFuture
 
 @RestController
 class MemberController(
@@ -30,8 +29,8 @@ class MemberController(
 ) {
 
     @PostMapping("/auth/sign-up/email-validation")
-    fun sendValidationCode(@RequestBody request: SendCodeRequest): CompletableFuture<String> {
-        return codeService.sendCode(request.email)
+    fun sendValidationCode(@RequestBody request: SendCodeRequest): ResponseEntity<Any> {
+        return ResponseEntity.status(HttpStatus.OK).body(codeService.sendCode(request.email))
     }
 
     @PostMapping("/auth/sign-up")

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
@@ -21,6 +21,7 @@ import sparta.nbcamp.wachu.domain.member.emailcode.dto.SendCodeRequest
 import sparta.nbcamp.wachu.domain.member.emailcode.service.CodeService
 import sparta.nbcamp.wachu.domain.member.service.MemberService
 import sparta.nbcamp.wachu.infra.security.jwt.UserPrincipal
+import java.util.concurrent.CompletableFuture
 
 @RestController
 class MemberController(
@@ -29,8 +30,8 @@ class MemberController(
 ) {
 
     @PostMapping("/auth/sign-up/email-validation")
-    fun sendValidationCode(@RequestBody request: SendCodeRequest): ResponseEntity<Any> {
-        return ResponseEntity.status(HttpStatus.OK).body(codeService.sendCode(request.email))
+    fun sendValidationCode(@RequestBody request: SendCodeRequest): CompletableFuture<String> {
+        return codeService.sendCode(request.email)
     }
 
     @PostMapping("/auth/sign-up")

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
@@ -21,7 +21,6 @@ import sparta.nbcamp.wachu.domain.member.emailcode.dto.SendCodeRequest
 import sparta.nbcamp.wachu.domain.member.emailcode.service.CodeService
 import sparta.nbcamp.wachu.domain.member.service.MemberService
 import sparta.nbcamp.wachu.infra.security.jwt.UserPrincipal
-import java.util.concurrent.CompletableFuture
 
 @RestController
 class MemberController(
@@ -30,8 +29,9 @@ class MemberController(
 ) {
 
     @PostMapping("/auth/sign-up/email-validation")
-    fun sendValidationCode(@RequestBody request: SendCodeRequest): CompletableFuture<String> {
-        return codeService.sendCode(request.email)
+    fun sendValidationCode(@RequestBody request: SendCodeRequest): ResponseEntity<Any> {
+        codeService.sendCode(request.email)
+        return ResponseEntity.ok("Email send successfully")
     }
 
     @PostMapping("/auth/sign-up")

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/emailcode/config/AsyncConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/emailcode/config/AsyncConfig.kt
@@ -1,0 +1,23 @@
+package sparta.nbcamp.wachu.domain.member.emailcode.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.AsyncConfigurer
+import org.springframework.scheduling.annotation.EnableAsync
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor
+import java.util.concurrent.Executor
+
+@Configuration
+@EnableAsync
+class AsyncConfig : AsyncConfigurer {
+    @Bean(name = ["mailExecutor"])
+    override fun getAsyncExecutor(): Executor {
+        val executor = ThreadPoolTaskExecutor()
+        executor.corePoolSize = 2
+        executor.maxPoolSize = 5
+        executor.queueCapacity = 10
+        executor.setThreadNamePrefix("Async MailExecutor-")
+        executor.initialize()
+        return executor
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/emailcode/service/CodeService.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/emailcode/service/CodeService.kt
@@ -7,7 +7,6 @@ import org.springframework.mail.SimpleMailMessage
 import org.springframework.mail.javamail.JavaMailSender
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Service
-import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
 
 @Service
@@ -17,7 +16,7 @@ class CodeService(
     @Value("\${spring.mail.username}") private val mailUsername: String
 ) {
     @Async("mailExecutor")
-    fun sendCode(email: String): CompletableFuture<String> {
+    fun sendCode(email: String) {
         val code = generateCode()
         saveCode(email, code)
 
@@ -27,11 +26,10 @@ class CodeService(
             subject = "Your Verification Code"
             text = "Your verification code is: $code."
         }
-        return try {
+        try {
             mailSender.send(message)
-            CompletableFuture.completedFuture("Email send successfully")
         } catch (e: MailSendException) {
-            CompletableFuture.failedFuture(e)
+            throw e
         }
     }
 

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/emailcode/service/CodeService.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/emailcode/service/CodeService.kt
@@ -21,8 +21,6 @@ class CodeService(
         val code = generateCode()
         saveCode(email, code)
 
-        val codeTimeout = redisTemplate.getExpire(email, TimeUnit.MINUTES)
-
         val message = SimpleMailMessage().apply {
             from = mailUsername
             setTo(email)
@@ -31,7 +29,7 @@ class CodeService(
         }
         return try {
             mailSender.send(message)
-            CompletableFuture.completedFuture("Verify within $codeTimeout minutes")
+            CompletableFuture.completedFuture("Email send successfully")
         } catch (e: MailSendException) {
             CompletableFuture.failedFuture(e)
         }


### PR DESCRIPTION

## 요약

> 이메일발송 속도 아니고 사용성 개선

## 작업 사항

> gmail smtp 서버 관련 속도 개선은 제한적이라 -> 비동기 스레드로 다른 api 안막히게 수정


## 리뷰 요청 사항(선택)

> ![image](https://github.com/user-attachments/assets/17cce612-0f62-4378-9b9e-a8a87fe937ec)
기본 스레드수 2
최대 스레드수 5
작업 대기열 크기 10
괜찮을가요?

---

### 해결한 이슈

closes: #93 
