### PR TITLE
♻️ #106 와인추천시 전체 조회 성능 개선

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ dev, feat/* ]
+    branches: [ dev, feat/*, refactor/*, bug/* ]
   pull_request:
     branches:
       - dev

--- a/src/main/kotlin/sparta/nbcamp/wachu/WachuApplication.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/WachuApplication.kt
@@ -2,8 +2,10 @@ package sparta.nbcamp.wachu
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootApplication
+@EnableScheduling
 class WachuApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/dto/WineResponse.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/dto/WineResponse.kt
@@ -3,6 +3,7 @@ package sparta.nbcamp.wachu.domain.wine.dto
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
 import sparta.nbcamp.wachu.domain.wine.service.WineImageGetter
+import sparta.nbcamp.wachu.infra.openai.dto.WineDataResponse
 import java.io.Serializable
 
 data class WineResponse(
@@ -23,7 +24,6 @@ data class WineResponse(
     val imageUrl: String
 ) : Serializable {
     companion object {
-
         fun from(entity: Wine): WineResponse {
             return WineResponse(
                 id = entity.id,
@@ -40,6 +40,25 @@ data class WineResponse(
                 country = entity.country,
                 region = entity.region,
                 imageUrl = WineImageGetter.getWineImage(entity.wineType)
+            )
+        }
+
+        fun convert(dto: WineDataResponse): WineResponse {
+            return WineResponse(
+                id = dto.id,
+                name = dto.name,
+                sweetness = dto.sweetness,
+                acidity = dto.acidity,
+                body = dto.body,
+                tannin = dto.tannin,
+                wineType = dto.wineType,
+                aroma = dto.aroma,
+                price = dto.price,
+                kind = dto.kind,
+                style = dto.style,
+                country = dto.country,
+                region = dto.region,
+                imageUrl = WineImageGetter.getWineImage(dto.wineType)
             )
         }
     }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepository.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepository.kt
@@ -5,7 +5,7 @@ import org.springframework.data.domain.Pageable
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
 
 interface WineRepository {
-    fun findAll(pageable: Pageable): Page<Wine>
+    fun findAll(): List<Wine>
 
     fun findByNameContaining(query: String, pageable: Pageable): Page<Wine>
 

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepositoryImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/repository/WineRepositoryImpl.kt
@@ -12,8 +12,8 @@ class WineRepositoryImpl(
     private val wineQueryDslRepository: WineQueryDslRepository
 ) : WineRepository {
 
-    override fun findAll(pageable: Pageable): Page<Wine> {
-        return wineJpaRepository.findAll(pageable)
+    override fun findAll(): List<Wine> {
+        return wineJpaRepository.findAll()
     }
 
     override fun findByNameContaining(query: String, pageable: Pageable): Page<Wine> {

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineImageGetter.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineImageGetter.kt
@@ -1,15 +1,13 @@
 package sparta.nbcamp.wachu.domain.wine.service
 
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
-import sparta.nbcamp.wachu.infra.aws.s3.S3FilePath
 import sparta.nbcamp.wachu.infra.media.MediaS3Service
 
 object WineImageGetter {
     private lateinit var mediaS3Service: MediaS3Service
 
     fun getWineImage(wineType: WineType): String {
-        val list = mediaS3Service.getS3Image(S3FilePath.WINE.path + wineType.path)
-        list.forEach { println(it) }
+        val list = mediaS3Service.getInMemoryDirectory(wineType)
         return if (list.isNotEmpty()) {
             list.removeFirst()//첫번째 원소는 파일경로만 있어서 제외
             list.random()

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/wine/service/WineServiceImpl.kt
@@ -82,7 +82,7 @@ class WineServiceImpl @Autowired constructor(
 
     override fun recommendWine(request: RecommendWineRequest): List<WineResponse> {
         return wineEmbeddingService.recommendWine(request.preferWineId)
-            .map { it.first.wine }
+            .map { WineResponse.convert(it.first.wine) }
     }
 
     private fun getDirection(sort: String) = when (sort.lowercase()) {

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3CreateEvent.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3CreateEvent.kt
@@ -1,5 +1,0 @@
-package sparta.nbcamp.wachu.infra.aws.s3
-
-import org.springframework.context.ApplicationEvent
-
-class S3CreateEvent(source: Any) : ApplicationEvent(source)

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3CreateEvent.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3CreateEvent.kt
@@ -1,0 +1,5 @@
+package sparta.nbcamp.wachu.infra.aws.s3
+
+import org.springframework.context.ApplicationEvent
+
+class S3CreateEvent(source: Any) : ApplicationEvent(source)

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
@@ -2,6 +2,9 @@ package sparta.nbcamp.wachu.infra.aws.s3
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
@@ -13,6 +16,7 @@ import java.io.IOException
 @Service
 class S3Service @Autowired constructor(
     private val s3client: S3Client,
+    private val eventPublisher: ApplicationEventPublisher
 ) {
     @Value("\${aws.s3.bucket}")
     private lateinit var bucket: String
@@ -45,5 +49,10 @@ class S3Service @Autowired constructor(
         return imageList.contents().map {
             "https://cdn.sober-wachu.com/${it.key()}"
         }
+    }
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun onApplicationReadyEvent(event: ApplicationReadyEvent) {
+        eventPublisher.publishEvent(S3CreateEvent(this))
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/s3/S3Service.kt
@@ -2,9 +2,7 @@ package sparta.nbcamp.wachu.infra.aws.s3
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
 import software.amazon.awssdk.core.sync.RequestBody
@@ -49,10 +47,5 @@ class S3Service @Autowired constructor(
         return imageList.contents().map {
             "https://cdn.sober-wachu.com/${it.key()}"
         }
-    }
-
-    @EventListener(ApplicationReadyEvent::class)
-    fun onApplicationReadyEvent(event: ApplicationReadyEvent) {
-        eventPublisher.publishEvent(S3CreateEvent(this))
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/InMemoryDirectory.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/InMemoryDirectory.kt
@@ -1,0 +1,21 @@
+package sparta.nbcamp.wachu.infra.batches.s3directory
+
+import org.springframework.stereotype.Component
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
+
+@Component
+class InMemoryDirectory {
+    private val directory = HashMap<WineType, List<String>>()
+
+    fun set(key: WineType, values: List<String>) {
+        synchronized(this) {
+            directory[key] = values
+        }
+    }
+
+    fun get(key: WineType): List<String>? {
+        return synchronized(this) {
+            directory[key]
+        }
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
@@ -1,11 +1,10 @@
 package sparta.nbcamp.wachu.infra.batches.s3directory
 
-import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
+import sparta.nbcamp.wachu.infra.aws.s3.S3CreateEvent
 import sparta.nbcamp.wachu.infra.aws.s3.S3FilePath
 import sparta.nbcamp.wachu.infra.aws.s3.S3Service
 
@@ -15,9 +14,8 @@ class S3DirectoryBatchJob(
     private val inMemoryDirectory: InMemoryDirectory
 ) {
 
-    @Async
-    @EventListener(ApplicationReadyEvent::class)
-    fun onApplicationEvent(event: ApplicationReadyEvent) {
+    @EventListener(S3CreateEvent::class)
+    fun onS3CreateEvent(event: S3CreateEvent) {
         job()
     }
 

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
@@ -1,6 +1,7 @@
 package sparta.nbcamp.wachu.infra.batches.s3directory
 
-import jakarta.annotation.PostConstruct
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
@@ -11,9 +12,9 @@ import sparta.nbcamp.wachu.infra.aws.s3.S3Service
 class S3DirectoryBatchJob(
     private val s3Service: S3Service,
     private val inMemoryDirectory: InMemoryDirectory
-) {
-    @PostConstruct
-    fun init() {
+) : ApplicationListener<ApplicationReadyEvent> {
+
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
         job()
     }
 

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
@@ -1,8 +1,8 @@
 package sparta.nbcamp.wachu.infra.batches.s3directory
 
 import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.annotation.Profile
 import org.springframework.context.event.EventListener
-import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
@@ -10,12 +10,12 @@ import sparta.nbcamp.wachu.infra.aws.s3.S3FilePath
 import sparta.nbcamp.wachu.infra.aws.s3.S3Service
 
 @Component
+@Profile("!test")
 class S3DirectoryBatchJob(
     private val s3Service: S3Service,
     private val inMemoryDirectory: InMemoryDirectory
 ) {
 
-    @Async
     @EventListener(ApplicationReadyEvent::class)
     fun onApplicationEvent(event: ApplicationReadyEvent) {
         job()

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
@@ -1,10 +1,11 @@
 package sparta.nbcamp.wachu.infra.batches.s3directory
 
+import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
-import sparta.nbcamp.wachu.infra.aws.s3.S3CreateEvent
 import sparta.nbcamp.wachu.infra.aws.s3.S3FilePath
 import sparta.nbcamp.wachu.infra.aws.s3.S3Service
 
@@ -14,8 +15,9 @@ class S3DirectoryBatchJob(
     private val inMemoryDirectory: InMemoryDirectory
 ) {
 
-    @EventListener(S3CreateEvent::class)
-    fun onS3CreateEvent(event: S3CreateEvent) {
+    @Async
+    @EventListener(ApplicationReadyEvent::class)
+    fun onApplicationEvent(event: ApplicationReadyEvent) {
         job()
     }
 

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
@@ -1,0 +1,30 @@
+package sparta.nbcamp.wachu.infra.batches.s3directory
+
+import jakarta.annotation.PostConstruct
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Component
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
+import sparta.nbcamp.wachu.infra.aws.s3.S3FilePath
+import sparta.nbcamp.wachu.infra.aws.s3.S3Service
+
+@Component
+class S3DirectoryBatchJob(
+    private val s3Service: S3Service,
+    private val inMemoryDirectory: InMemoryDirectory
+) {
+    @PostConstruct
+    fun init() {
+        job()
+    }
+
+    @Scheduled(cron = "0 0 * * * *")
+    fun job() {
+        WineType.entries.forEach {
+            s3Service.getImage(S3FilePath.WINE.path + it.path)
+                .also { element ->
+                    println(element.toString())
+                    inMemoryDirectory.set(it, element)
+                }
+        }
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/s3directory/S3DirectoryBatchJob.kt
@@ -1,7 +1,8 @@
 package sparta.nbcamp.wachu.infra.batches.s3directory
 
 import org.springframework.boot.context.event.ApplicationReadyEvent
-import org.springframework.context.ApplicationListener
+import org.springframework.context.event.EventListener
+import org.springframework.scheduling.annotation.Async
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Component
 import sparta.nbcamp.wachu.domain.wine.entity.WineType
@@ -12,9 +13,11 @@ import sparta.nbcamp.wachu.infra.aws.s3.S3Service
 class S3DirectoryBatchJob(
     private val s3Service: S3Service,
     private val inMemoryDirectory: InMemoryDirectory
-) : ApplicationListener<ApplicationReadyEvent> {
+) {
 
-    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+    @Async
+    @EventListener(ApplicationReadyEvent::class)
+    fun onApplicationEvent(event: ApplicationReadyEvent) {
         job()
     }
 

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/DataLoadCompleteEvent.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/DataLoadCompleteEvent.kt
@@ -1,0 +1,5 @@
+package sparta.nbcamp.wachu.infra.batches.winedata
+
+import org.springframework.context.ApplicationEvent
+
+class DataLoadCompleteEvent(source: Any) : ApplicationEvent(source)

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/InMemoryCache.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/InMemoryCache.kt
@@ -1,0 +1,28 @@
+package sparta.nbcamp.wachu.infra.batches.winedata
+
+import org.springframework.stereotype.Component
+import sparta.nbcamp.wachu.domain.wine.entity.Wine
+
+@Component
+class InMemoryCache {
+    private val wines = mutableListOf<Wine>()
+
+    fun loadWines(newWines: List<Wine>) {
+        synchronized(this) {
+            wines.clear()
+            wines.addAll(newWines)
+        }
+    }
+
+    fun getWines(): List<Wine> {
+        return synchronized(this) {
+            wines.toList()
+        }
+    }
+
+    fun getWine(id: Long): Wine? {
+        return synchronized(this) {
+            wines.find { it.id == id }
+        }
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/WineDataBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/WineDataBatchJob.kt
@@ -2,7 +2,7 @@ package sparta.nbcamp.wachu.infra.batches.winedata
 
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationEventPublisher
-import org.springframework.context.ApplicationListener
+import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import sparta.nbcamp.wachu.domain.wine.repository.WineRepository
@@ -12,10 +12,11 @@ class WineDataBatchJob(
     private val wineRepository: WineRepository,
     private val inMemoryCache: InMemoryCache,
     private val eventPublisher: ApplicationEventPublisher
-) : ApplicationListener<ApplicationReadyEvent> {
+) {
 
     @Async
-    override fun onApplicationEvent(event: ApplicationReadyEvent) {
+    @EventListener(ApplicationReadyEvent::class)
+    fun onApplicationEvent(event: ApplicationReadyEvent) {
         val wines = wineRepository.findAll()
         inMemoryCache.loadWines(wines)
         eventPublisher.publishEvent(DataLoadCompleteEvent(this))

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/WineDataBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/WineDataBatchJob.kt
@@ -1,0 +1,23 @@
+package sparta.nbcamp.wachu.infra.batches.winedata
+
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.context.ApplicationListener
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.scheduling.annotation.Async
+import org.springframework.stereotype.Component
+import sparta.nbcamp.wachu.domain.wine.repository.WineRepository
+
+@Component
+class WineDataBatchJob(
+    private val wineRepository: WineRepository,
+    private val inMemoryCache: InMemoryCache,
+    private val eventPublisher: ApplicationEventPublisher
+) : ApplicationListener<ContextRefreshedEvent> {
+
+    @Async
+    override fun onApplicationEvent(event: ContextRefreshedEvent) {
+        val wines = wineRepository.findAll()
+        inMemoryCache.loadWines(wines)
+        eventPublisher.publishEvent(DataLoadCompleteEvent(this))
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/WineDataBatchJob.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/batches/winedata/WineDataBatchJob.kt
@@ -1,8 +1,8 @@
 package sparta.nbcamp.wachu.infra.batches.winedata
 
+import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.ApplicationListener
-import org.springframework.context.event.ContextRefreshedEvent
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import sparta.nbcamp.wachu.domain.wine.repository.WineRepository
@@ -12,10 +12,10 @@ class WineDataBatchJob(
     private val wineRepository: WineRepository,
     private val inMemoryCache: InMemoryCache,
     private val eventPublisher: ApplicationEventPublisher
-) : ApplicationListener<ContextRefreshedEvent> {
+) : ApplicationListener<ApplicationReadyEvent> {
 
     @Async
-    override fun onApplicationEvent(event: ContextRefreshedEvent) {
+    override fun onApplicationEvent(event: ApplicationReadyEvent) {
         val wines = wineRepository.findAll()
         inMemoryCache.loadWines(wines)
         eventPublisher.publishEvent(DataLoadCompleteEvent(this))

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3Service.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3Service.kt
@@ -1,9 +1,11 @@
 package sparta.nbcamp.wachu.infra.media
 
 import org.springframework.web.multipart.MultipartFile
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
 
 interface MediaS3Service {
     fun upload(file: MultipartFile, filePath: String): String
     fun upload(fileList: List<MultipartFile>, filePath: String): List<String>
     fun getS3Image(filePath: String): MutableList<String>
+    fun getInMemoryDirectory(type: WineType): MutableList<String>
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3ServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3ServiceImpl.kt
@@ -4,14 +4,17 @@ import jakarta.annotation.PostConstruct
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.multipart.MultipartFile
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
 import sparta.nbcamp.wachu.domain.wine.service.WineImageGetter
 import sparta.nbcamp.wachu.infra.aws.s3.S3Service
+import sparta.nbcamp.wachu.infra.batches.s3directory.InMemoryDirectory
 import sparta.nbcamp.wachu.infra.tika.TikaUtil
 
 @Service
 class MediaS3ServiceImpl(
     private val s3Service: S3Service,
-    private val tikaUtil: TikaUtil
+    private val tikaUtil: TikaUtil,
+    private val inMemoryDirectory: InMemoryDirectory
 ) : MediaS3Service {
     private val logger = LoggerFactory.getLogger(MediaS3Service::class.java)
     override fun upload(file: MultipartFile, filePath: String): String {
@@ -34,6 +37,10 @@ class MediaS3ServiceImpl(
     override fun getS3Image(filePath: String): MutableList<String> {
         //경로 안에 모든 파일을 불러옴
         return s3Service.getImage(filePath).toMutableList()
+    }
+
+    override fun getInMemoryDirectory(type: WineType): MutableList<String> {
+        return inMemoryDirectory.get(type)!!.toMutableList()
     }
 
     @PostConstruct

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/dto/WineDataResponse.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/dto/WineDataResponse.kt
@@ -1,0 +1,42 @@
+package sparta.nbcamp.wachu.infra.openai.dto
+
+import sparta.nbcamp.wachu.domain.wine.entity.Wine
+import sparta.nbcamp.wachu.domain.wine.entity.WineType
+import java.io.Serializable
+
+data class WineDataResponse(
+    val id: Long,
+    val name: String,
+    val sweetness: Int,
+    val acidity: Int,
+    val body: Int,
+    val tannin: Int,
+    val wineType: WineType,
+    val aroma: String,
+    val price: Int?,
+    val kind: String?,
+    val style: String?,
+    val country: String?,
+    val region: String?,
+) : Serializable {
+    companion object {
+
+        fun from(entity: Wine): WineDataResponse {
+            return WineDataResponse(
+                id = entity.id,
+                name = entity.name,
+                sweetness = entity.sweetness,
+                acidity = entity.acidity,
+                body = entity.body,
+                tannin = entity.tannin,
+                wineType = entity.wineType,
+                aroma = entity.aroma,
+                price = entity.price,
+                kind = entity.kind,
+                style = entity.style,
+                country = entity.country,
+                region = entity.region,
+            )
+        }
+    }
+}

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/dto/WineEmbeddingData.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/dto/WineEmbeddingData.kt
@@ -1,10 +1,9 @@
 package sparta.nbcamp.wachu.infra.openai.dto
 
-import sparta.nbcamp.wachu.domain.wine.dto.WineResponse
 import sparta.nbcamp.wachu.domain.wine.entity.Wine
 
 data class WineEmbeddingData(
-    val wine: WineResponse,
+    val wine: WineDataResponse,
     val data: List<WineEmbeddingDataItem>
 ) {
     fun aromaFilteredList(): WineEmbeddingData {
@@ -30,7 +29,7 @@ data class WineEmbeddingData(
                 }
                 .let {
                     WineEmbeddingData(
-                        WineResponse.from(wine),
+                        WineDataResponse.from(wine),
                         it
                     )
                 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/service/WineEmbeddingService.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/service/WineEmbeddingService.kt
@@ -1,9 +1,9 @@
 package sparta.nbcamp.wachu.infra.openai.service
 
-import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import sparta.nbcamp.wachu.domain.wine.repository.WineRepository
 import sparta.nbcamp.wachu.exception.ModelNotFoundException
+import sparta.nbcamp.wachu.infra.batches.winedata.InMemoryCache
 import sparta.nbcamp.wachu.infra.openai.common.utils.WineEmbeddingUtility
 import sparta.nbcamp.wachu.infra.openai.dto.WineEmbeddingData
 
@@ -11,6 +11,8 @@ import sparta.nbcamp.wachu.infra.openai.dto.WineEmbeddingData
 class WineEmbeddingService(
     private val wineRepository: WineRepository,
     private val embeddingUtility: WineEmbeddingUtility,
+    private val inMemoryCache: InMemoryCache,
+    private val wineEventListener: WineEventListener
 ) {
     private var minPrice: Int = 0
     private var maxPrice: Int = 0
@@ -21,7 +23,7 @@ class WineEmbeddingService(
     }
 
     fun createEveryWineEmbedding(): List<WineEmbeddingData> {
-        return wineRepository.findAll(Pageable.unpaged()).content
+        return wineRepository.findAll()
             .map { WineEmbeddingData.fromWine(it) }
             .map { wineEmbeddingData ->
                 val transformedData = embeddingUtility.inputListToEmbeddingData(
@@ -48,9 +50,10 @@ class WineEmbeddingService(
     }
 
     fun recommendWine(wineId: Long): List<Pair<WineEmbeddingData, Double>> {
+        if (!wineEventListener.isLoaded()) throw IllegalStateException("데이터 로드중")
         return embeddingUtility.recommendWineList(
-            targetWine = wineRepository.findByIdOrNull(wineId) ?: throw ModelNotFoundException("wine", wineId),
-            everyWineList = wineRepository.findAll(Pageable.ofSize(100)).content
+            targetWine = inMemoryCache.getWine(wineId) ?: throw ModelNotFoundException("wine", wineId),
+            everyWineList = inMemoryCache.getWines()
         )
     }
 

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/service/WineEventListener.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/openai/service/WineEventListener.kt
@@ -1,0 +1,17 @@
+package sparta.nbcamp.wachu.infra.openai.service
+
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import sparta.nbcamp.wachu.infra.batches.winedata.DataLoadCompleteEvent
+
+@Component
+class WineEventListener {
+    private var dataLoaded: Boolean = false
+
+    @EventListener
+    fun onDataLoadComplete(event: DataLoadCompleteEvent) {
+        dataLoaded = true
+    }
+
+    fun isLoaded() = dataLoaded
+}


### PR DESCRIPTION
## 요약

> 와인 추천 로직 성능 개선

## 작업 사항

> 와인 데이터 인메모리 화
- 초기 실행때 비동기로 메모리 적재 시도
- 와인 정보는 변경사항이 없는 데이터라 불필요한 쿼리 호출 개선 목적
- 서비스는 따로 계속 빌드됨
- 서비스는 운영되나, 와인데이터가 계속 적재중이면 비즈니스 로직(와인추천)이 막힘
- 전부 적재되면 해금 이벤트 발행
- 이벤트가 완료되면 그때부터 비즈니스 로직까지 활성 

> S3 디렉토리 인메모리 화
- 초기 실행시 S3의 지정디렉토리 url을 매핑
- 그 후 스케줄러를 통해 정각마다 url업데이트
- 와인 이미지는 변경이 적은 이미지라 인메모리만으로 비즈니스 로직 수행
- S3 직접 접근을 줄여 불필요한 네트워크 리소스를 아낌
---

### 해결한 이슈

closes: #106 
