### PR TITLE
:bug: 탈퇴한 유저 조회 실패

### DIFF
--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/entity/Member.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/entity/Member.kt
@@ -10,14 +10,12 @@ import jakarta.persistence.Id
 import jakarta.persistence.Table
 import org.hibernate.annotations.CreationTimestamp
 import org.hibernate.annotations.SQLDelete
-import org.hibernate.annotations.SQLRestriction
 import org.springframework.security.crypto.password.PasswordEncoder
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "member")
 @SQLDelete(sql = "UPDATE member SET is_deleted = true, deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
-@SQLRestriction("is_deleted = false")
 class Member(
 
     @Column(name = "email", length = 50, unique = true)


### PR DESCRIPTION
## 요약

> 간단 요약

유저가 탈퇴한 상태라서 soft delete 되면 다른 entity api 에서 조회할 때 로직때문에 실패함

## 작업 사항

> PR에서 작업한 사항들을 적어주세요(이미지, 스크린샷등을 활용해도 좋아요)

 sqlrestriction 제거

## 리뷰 요청 사항(선택)

> 리뷰시 봐주었으면 하는 부분이 있다면 적어주세요

---

### 해결한 이슈

closes: #123
