### PR TITLE
🐛 : 이미지 프리사인드 유알엘

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
 
     //aws
     implementation("software.amazon.awssdk:s3:2.20.0")
+    implementation("software.amazon.awssdk:sts:2.20.0")
     implementation("org.springframework.cloud:spring-cloud-starter-aws:2.0.1.RELEASE")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,7 +83,6 @@ dependencies {
     //Apache Tika
     implementation("org.apache.tika:tika-core:2.4.1")
     implementation("org.apache.tika:tika-parsers-standard-package:2.4.1")
-    implementation("org.apache.httpcomponents:httpclient:4.5.14")
 
     //EmailValidation
     implementation("org.springframework.boot:spring-boot-starter-mail")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -83,6 +83,7 @@ dependencies {
     //Apache Tika
     implementation("org.apache.tika:tika-core:2.4.1")
     implementation("org.apache.tika:tika-parsers-standard-package:2.4.1")
+    implementation("org.apache.httpcomponents:httpclient:4.5.14")
 
     //EmailValidation
     implementation("org.springframework.boot:spring-boot-starter-mail")

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/controller/MemberController.kt
@@ -124,4 +124,13 @@ class MemberController(
         val tokenResponse = memberService.refreshAccessToken(refreshToken)
         return ResponseEntity.ok().body(tokenResponse.accessToken)
     }
+
+    @PostMapping(
+        "/test/image",
+        consumes = [MediaType.MULTIPART_FORM_DATA_VALUE],
+        produces = [MediaType.APPLICATION_JSON_VALUE]
+    )
+    fun testImage(@RequestPart(name = "image") multipartFile: MultipartFile): ResponseEntity<String> {
+        return ResponseEntity.ok().body(memberService.testImage(multipartFile))
+    }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/service/MemberService.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/service/MemberService.kt
@@ -32,4 +32,6 @@ interface MemberService {
     fun socialLogin(request: OAuthResponse): TokenResponse
 
     fun refreshAccessToken(refreshToken: String): TokenResponse
+
+    fun testImage(multipartFile: MultipartFile): String
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/member/service/MemberServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/member/service/MemberServiceImpl.kt
@@ -164,4 +164,8 @@ class MemberServiceImpl @Autowired constructor(
             onFailure = { throw IllegalStateException(" 토큰이 검증되지않음") }
         )
     }
+
+    override fun testImage(multipartFile: MultipartFile): String {
+        return mediaS3Service.getPresignedUrl(multipartFile, S3FilePath.PROFILE.path).toString()
+    }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/service/v1/PairingServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/domain/pairing/service/v1/PairingServiceImpl.kt
@@ -56,8 +56,8 @@ class PairingServiceImpl(
         val member = memberRepository.findById(userPrincipal.memberId)
             ?: throw ModelNotFoundException("Member", userPrincipal.memberId)
 
-        val imageUrl = multipartFile.let { mediaS3Service.upload(multipartFile, S3FilePath.PAIRING.path) }
-        val pairing = pairingRequest.toEntity(wine, member.id!!, imageUrl)
+        val imageUrl = multipartFile.let { mediaS3Service.getPresignedUrl(multipartFile, S3FilePath.PAIRING.path) }
+        val pairing = pairingRequest.toEntity(wine, member.id!!, imageUrl.toString())
 
         return PairingResponse.from(pairingRepository.save(pairing), member)
     }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/AwsConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/AwsConfig.kt
@@ -29,8 +29,10 @@ class AwsConfig {
 
     @Bean
     fun s3Presigner(): S3Presigner {
+        val credentials = AwsBasicCredentials.create(accessKey, secretKey)
         return S3Presigner.builder()
             .region(Region.AP_NORTHEAST_2) // 원하는 지역으로 설정
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
             .build()
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/AwsConfig.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/aws/AwsConfig.kt
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.s3.S3Client
+import software.amazon.awssdk.services.s3.presigner.S3Presigner
 
 @Configuration
 class AwsConfig {
@@ -23,6 +24,13 @@ class AwsConfig {
         return S3Client.builder()
             .region(Region.AP_NORTHEAST_2) // 원하는 지역으로 설정
             .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build()
+    }
+
+    @Bean
+    fun s3Presigner(): S3Presigner {
+        return S3Presigner.builder()
+            .region(Region.AP_NORTHEAST_2) // 원하는 지역으로 설정
             .build()
     }
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3Service.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3Service.kt
@@ -1,9 +1,11 @@
 package sparta.nbcamp.wachu.infra.media
 
 import org.springframework.web.multipart.MultipartFile
+import java.net.URL
 
 interface MediaS3Service {
     fun upload(file: MultipartFile, filePath: String): String
     fun upload(fileList: List<MultipartFile>, filePath: String): List<String>
     fun getS3Image(filePath: String): MutableList<String>
+    fun getPresignedUrl(file: MultipartFile, filePath: String): URL
 }

--- a/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3ServiceImpl.kt
+++ b/src/main/kotlin/sparta/nbcamp/wachu/infra/media/MediaS3ServiceImpl.kt
@@ -7,6 +7,7 @@ import org.springframework.web.multipart.MultipartFile
 import sparta.nbcamp.wachu.domain.wine.service.WineImageGetter
 import sparta.nbcamp.wachu.infra.aws.s3.S3Service
 import sparta.nbcamp.wachu.infra.tika.TikaUtil
+import java.net.URL
 
 @Service
 class MediaS3ServiceImpl(
@@ -34,6 +35,14 @@ class MediaS3ServiceImpl(
     override fun getS3Image(filePath: String): MutableList<String> {
         //경로 안에 모든 파일을 불러옴
         return s3Service.getImage(filePath).toMutableList()
+    }
+
+    override fun getPresignedUrl(file: MultipartFile, filePath: String): URL {
+        if (!tikaUtil.validateMediaFile(file)) {
+            throw IllegalArgumentException("Invalid file format")
+        }
+        logger.info("upload file: $filePath")
+        return s3Service.generatePresignedUrl(file, filePath)
     }
 
     @PostConstruct


### PR DESCRIPTION

## 요약

> 크리에이트 페어링에 적용함-> 리뷰 후 리뷰에도 적용해야함

## 작업 사항

> 프리사인드 적용된 부분: 페어링 생성, 멤버쪽에서 테스트용 이미지

## 리뷰 요청 사항(선택)

> 멤버컨트롤러에 프리사인드 테스트용 이미지올리는 기능이 있는데요. 이게 안되는거 보니깐요. 
> 필요하면 aws 들어가서 설정을 건들여야할거 같습니다.

---

### 해결한 이슈

closes: #이슈번호
